### PR TITLE
Ignoring comment text in common markdown prefixes

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -143,7 +143,8 @@ helpers do
   # Simply parse the comment for plus ones
   def parse_comment_body(comment_body)
     # Ignore common markdown prefixes
-    comment_body = comment_body.sub(/^(>\s|#{1,4}\s|\*\s|\+\s).+/s, '')
+    markdown_regex_pattern = Regexp.new('/^(>\s|#{1,4}\s|\*\s|\+\s).+/s')
+    comment_body = comment_body.sub(markdown_regex_pattern, '')
 
     plus_one_regex_pattern = Regexp.new('(' + Regexp.escape(PLUS_ONE_COMMENT) + ')')
     neg_one_regex_pattern = Regexp.new('(' + Regexp.escape(NEG_ONE_COMMENT) + ')')

--- a/app.rb
+++ b/app.rb
@@ -143,7 +143,7 @@ helpers do
   # Simply parse the comment for plus ones
   def parse_comment_body(comment_body)
     # Ignore common markdown prefixes
-    comment_body = comment_body.sub(/^(>\s|#\s|\*\s|\+\s).*/)
+    comment_body = comment_body.sub(/^(>\s|#\s|\*\s|\+\s).*/, '')
 
     plus_one_regex_pattern = Regexp.new('(' + Regexp.escape(PLUS_ONE_COMMENT) + ')')
     neg_one_regex_pattern = Regexp.new('(' + Regexp.escape(NEG_ONE_COMMENT) + ')')

--- a/app.rb
+++ b/app.rb
@@ -142,8 +142,15 @@ helpers do
 
   # Simply parse the comment for plus ones
   def parse_comment_body(comment_body)
-    net_pluses = comment_body.scan(PLUS_ONE_COMMENT).count
-    net_pluses = net_pluses - comment_body.scan(NEG_ONE_COMMENT).count
+    # Ignore common markdown prefixes
+    comment_body = comment_body.sub(/^(>\s|#\s|\*\s|\+\s).*/)
+
+    plus_one_regex_pattern = Regexp.new('(' + Regexp.escape(PLUS_ONE_COMMENT) + ')')
+    neg_one_regex_pattern = Regexp.new('(' + Regexp.escape(NEG_ONE_COMMENT) + ')')
+
+    total_plus = comment_body.scan(plus_one_regex_pattern).count
+    total_neg = comment_body.scan(neg_one_regex_pattern).count
+    net_pluses = total_plus - total_neg
 
     if net_pluses > 0
       net_pluses = 1

--- a/app.rb
+++ b/app.rb
@@ -143,7 +143,7 @@ helpers do
   # Simply parse the comment for plus ones
   def parse_comment_body(comment_body)
     # Ignore common markdown prefixes
-    comment_body = comment_body.sub(/^(>\s|#\s|\*\s|\+\s).*/, '')
+    comment_body = comment_body.sub(/^(>\s|#{1,4}\s|\*\s|\+\s).+/s, '')
 
     plus_one_regex_pattern = Regexp.new('(' + Regexp.escape(PLUS_ONE_COMMENT) + ')')
     neg_one_regex_pattern = Regexp.new('(' + Regexp.escape(NEG_ONE_COMMENT) + ')')

--- a/app.rb
+++ b/app.rb
@@ -143,8 +143,7 @@ helpers do
   # Simply parse the comment for plus ones
   def parse_comment_body(comment_body)
     # Ignore common markdown prefixes
-    markdown_regex_pattern = Regexp.new('/^(>\s|#{1,4}\s|\*\s|\+\s).+/s')
-    comment_body = comment_body.sub(markdown_regex_pattern, '')
+    comment_body = comment_body.gsub(/^(>\s|\#{1,4}\s|\*\s|\+\s).+/s, '')
 
     plus_one_regex_pattern = Regexp.new('(' + Regexp.escape(PLUS_ONE_COMMENT) + ')')
     neg_one_regex_pattern = Regexp.new('(' + Regexp.escape(NEG_ONE_COMMENT) + ')')


### PR DESCRIPTION
This PR hopefully fixes https://github.com/robinpowered/commodus/issues/8 by ignoring certain markdown prefixes when checking for the :+1:.

**Invalid examples:**
> :+1: Great work!

+ Super job :+1: 

### Really good stuff! :+1: 

There might be a better regex pattern that I can't think of, but this is what I thought of.