### PR TITLE
Feature - GH Review Support

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -117,7 +117,7 @@ helpers do
     pr_name = review_payload['repository']['full_name'].to_s
     pr_number = review_payload['pull_request']['number'].to_s
     comment_user = review_payload['review']['user']['id'].to_s
-    approvals = (review_payload['review']['state'] == "approved") ? 1 : 0
+    approvals = evaluate_review_state(review_payload['review']['state'])
     current_commit_hash = review_payload['pull_request']['head']['sha'].to_s
 
     submit_status(pr_name, pr_number, current_commit_hash, comment_user, approvals)
@@ -195,6 +195,19 @@ helpers do
     end
 
     return 200
+  end
+
+  # Evaluates the PR review state
+  def evaluate_review_state(state)
+    net_pluses = 0
+
+    if state == "approved"
+      net_pluses = 1
+    elsif state == "changes_requested"
+      net_pluses = -1
+    end
+
+    return net_pluses
   end
 
   # Simply parse the comment for plus ones

--- a/app.rb
+++ b/app.rb
@@ -169,27 +169,20 @@ helpers do
       @redis.hset(pr_key, current_commit_hash, payload_to_store.to_json)
 
       if plus_ones >= NEEDED_PLUS_ONES
-        # Set commit status to sucessful
-        @client.create_status(
-          pr_name,
-          current_commit_hash,
-          'success',
-          {
-            'description' => 'Commodus: Required plus ones (' + plus_ones.to_s + '/' + NEEDED_PLUS_ONES.to_s + ') has been reached!',
-            'context' => 'robinpowered/commodus'
-          }
-        )
+        status = 'success'
       else
-        @client.create_status(
-          pr_name,
-          current_commit_hash,
-          'pending',
-          {
-            'description' => 'Commodus: Required plus ones (' + plus_ones.to_s + '/' + NEEDED_PLUS_ONES.to_s + ') has yet to be reached.',
-            'context' => 'robinpowered/commodus'
-          }
-        )
+        status = 'pending'
       end
+
+      @client.create_status(
+        pr_name,
+        current_commit_hash,
+        status,
+        {
+          'description' => '(' + plus_ones.to_s + '/' + NEEDED_PLUS_ONES.to_s + ') required approvals.',
+          'context' => 'robinpowered/commodus'
+        }
+      ) 
     else
       return 404
     end


### PR DESCRIPTION
This PR adds support for GH PR reviews.

A review approval will be treated as a 👍 .
A review changes requested will be treated as a 👎 .

I also changed the status description so it is no longer truncated in the PR UI. Unfortunately it seems the GH API has a limitation on unicode characters sent up so I wasn't able to use 👍  in the status description 😢 .