### PR TITLE
Correctly setting plus one count for initial message

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -80,7 +80,7 @@ helpers do
       commit_hash,
       'pending',
       {
-        'description' => '(' + plus_ones.to_s + '/' + NEEDED_PLUS_ONES.to_s + ') required approvals.',
+        'description' => '(0/' + NEEDED_PLUS_ONES.to_s + ') required approvals.',
         'context' => 'robinpowered/commodus'
       }
     )


### PR DESCRIPTION
Fixes a small uninitialized variable from https://github.com/robinpowered/commodus/pull/17.
